### PR TITLE
Allow async migration function.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,11 @@ export default function persistStore(store, adapter, conf) {
       state.version < version
     ) {
       if (conf.migration) {
-        store.setState(
-          Object.assign({}, conf.migration(state, version), { hydrated: true }),
-        );
+        Promise.resolve(conf.migration(state, version)).then(function(
+          migrated,
+        ) {
+          store.setState(Object.assign({}, migrated, { hydrated: true }));
+        });
       } else {
         store.setState({ hydrated: true, version });
       }

--- a/test/unissist.test.js
+++ b/test/unissist.test.js
@@ -125,6 +125,32 @@ describe('unissist', () => {
     });
   });
 
+  it('should migrate the state with an async migration function', async () => {
+    let store = createStore();
+    cancel = unissist(store, adapter, { version: 1, debounceTime: 0 });
+    expect(await adapter.getState()).toBeUndefined();
+    store.setState({ a: 'b' });
+    await sleep(100);
+    expect(await adapter.getState()).toMatchObject({ a: 'b' });
+    cancel();
+
+    store = createStore();
+    store = createStore();
+    cancel = unissist(store, adapter, {
+      version: 2,
+      debounceTime: 0,
+      migration: () => Promise.resolve({ a: 'x' }),
+    });
+
+    await sleep(100);
+
+    expect(await adapter.getState()).toMatchObject({
+      a: 'x',
+      hydrated: true,
+      version: 2,
+    });
+  });
+
   it('should manipulate state on save when passed a reducer function', async () => {
     let store = createStore();
     cancel = unissist(store, adapter, {


### PR DESCRIPTION
I've added a `Promise.resolve` to the migration call and a test for async migrations.

Note the (at least imho) weird styling here is enforced by prettier:
https://github.com/Kanaye/unissist/blob/004c697843a02de06e701b49c4e01652d0229230/src/index.js#L25-L27
If you know why this happens and how I can resolve it, tell me.
I haven't really used prettier before and I'm therefore not familiar with it.

This PR adds 7 bytes:
Output from current master:
```
310 B
PASS  dist/unissist.js: 338B < maxSize 400B (gzip)
```
Output from this PR:
```
317 B
PASS  dist/unissist.js: 345B < maxSize 400B (gzip)
```

Closes #6